### PR TITLE
Fix schedule user is unset

### DIFF
--- a/incident_io_client/models/schedule_entry_v2_response_body.py
+++ b/incident_io_client/models/schedule_entry_v2_response_body.py
@@ -104,7 +104,7 @@ class ScheduleEntryV2ResponseBody:
 
         _user = d.pop("user", UNSET)
         user: Union[Unset, UserV2ResponseBody]
-        if isinstance(_user, Unset):
+        if isinstance(_user, Unset) or (_user is None):
             user = UNSET
         else:
             user = UserV2ResponseBody.from_dict(_user)


### PR DESCRIPTION
### Behavior

The `schedules_v2_list_schedule_entries.sync` function call fails with the following trace.

When a schedule is defined without an associated user then the following error ocuured.
```
Traceback (most recent call last):
  File "/xxx/src/get_oncall_report_incidentio.py", line 190, in <module>
    main()
  File "/xxx/src/get_oncall_report_incidentio.py", line 99, in main
    resp = schedules_v2_list_schedule_entries.sync(client=api_client, schedule_id=schedule_id, entry_window_start=query_start_time, entry_window_end=query_end_time)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/api/schedules_v2/schedules_v2_list_schedule_entries.py", line 131, in sync
    return sync_detailed(
           ^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/api/schedules_v2/schedules_v2_list_schedule_entries.py", line 104, in sync_detailed
    return _build_response(client=client, response=response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/api/schedules_v2/schedules_v2_list_schedule_entries.py", line 66, in _build_response
    parsed=_parse_response(client=client, response=response),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/api/schedules_v2/schedules_v2_list_schedule_entries.py", line 50, in _parse_response
    response_200 = SchedulesV2ListScheduleEntriesResponseBody.from_dict(response.json())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/models/schedules_v2_list_schedule_entries_response_body.py", line 93, in from_dict
    schedule_entries = ScheduleEntriesListPayloadV2ResponseBody.from_dict(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/models/schedule_entries_list_payload_v2_response_body.py", line 91, in from_dict
    final_item = ScheduleEntryV2ResponseBody.from_dict(final_item_data)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/models/schedule_entry_v2_response_body.py", line 114, in from_dict
    user = UserV2ResponseBody.from_dict(_user)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/xxx/.venv/lib/python3.11/site-packages/incident_io_client/models/user_v2_response_body.py", line 64, in from_dict
    d = src_dict.copy()
        ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'copy'
```

### Expected Behavior

The `schedules_v2_list_schedule_entries.sync` function returns the schedules even if there is assigned.