### PR TITLE
fix publish package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,8 +85,6 @@ jobs:
           poetry install --with dev --no-interaction --no-ansi --sync
 
       - name: Create new version and changelog
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           git config --local user.email "github-actions@githhub.com"
           git config --local user.name "Github Actions"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.cache/pre-commit
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-${{ env.PYTHON_VERSION_FOR_BUMPING }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: |
           pip install poetry~=${{ env.POETRY_VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,6 @@ env:
   POETRY_VERSION: "1.3"
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - "*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the caching mechanism in GitHub Actions for better flexibility in managing Python versions.
	- Removed manual trigger capability from the publish workflow, streamlining it to run only on tagged pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->