### PR TITLE
fix: use Github PAT token on creating new tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
+          token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0
       - name: Setup Python
         id: setup-python


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow security by adding a personal access token for authentication when checking out the repository.
  
- **Chores**
	- Updated GitHub Actions workflow configuration for improved access to private resources during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->