### PR TITLE
ci: runs only one instance of main workflow on non-default branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,8 @@ env:
   POETRY_VERSION: "1.6"
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: ${{ !(github.ref_name == github.event.repository.default_branch) }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   linting:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration to improve job concurrency management in GitHub Actions.
	- Enhanced cancellation logic for running jobs to ensure clarity and effectiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->